### PR TITLE
feat: add adminkey logic in the deleteQueja method in quejasController #33

### DIFF
--- a/src/controllers/quejasController.js
+++ b/src/controllers/quejasController.js
@@ -249,6 +249,15 @@ async getAllQuejas(req, res) {
                 });
             }
 
+            // Validar clave de administrador
+            const adminKey = req.body?.adminKey || req.query?.adminKey;
+            if (!adminKey || adminKey !== process.env.ADMIN_DELETE_KEY) {
+                return res.status(403).json({
+                    success: false,
+                    message: 'Clave de administrador incorrecta'
+                });
+            }
+
             // Verificar que la queja existe
             const existingQueja = await dbService.getQuejaById(validation.id);
             if (!existingQueja) {
@@ -258,9 +267,9 @@ async getAllQuejas(req, res) {
                 });
             }
 
-            // Eliminar la queja
+            // Eliminar la queja (marcar como deleted)
             const deleted = await dbService.deleteQueja(validation.id);
-            
+
             if (deleted) {
                 res.json({
                     success: true,

--- a/src/services/database.js
+++ b/src/services/database.js
@@ -218,9 +218,9 @@ class DatabaseService {
     }
 
     async deleteQueja(id) {
-        const query = 'DELETE FROM quejas WHERE id = ?';
-        const result = await this.execute(query, [id]);
-        return result.affectedRows > 0;
+    const query = 'UPDATE quejas SET deleted = 1 WHERE id = ?';
+    const result = await this.execute(query, [id]);
+    return result.affectedRows > 0;
     }
 
     // ==================== MÉTODOS PARA ESTADÍSTICAS ====================


### PR DESCRIPTION
The administrator password verification logic was implemented in the "deleteQueja" functionality in quejasController.